### PR TITLE
Support interfaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "join-monster-graphql-tools-adapter",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "Fetch data for your graph-tools schema using join-monster.",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ function decorateType(type, jmConfig) {
   const typeConfig = type._typeConfig
   typeConfig.sqlTable = jmConfig.sqlTable
   typeConfig.uniqueKey = jmConfig.uniqueKey
-  //These peoperties may appear for interface types
+  //These properties may appear for interface types
   if (jmConfig.typeHint) {
     typeConfig.typeHint = jmConfig.typeHint
   }

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,13 @@ function decorateType(type, jmConfig) {
   const typeConfig = type._typeConfig
   typeConfig.sqlTable = jmConfig.sqlTable
   typeConfig.uniqueKey = jmConfig.uniqueKey
+  //These peoperties may appear for interface types
+  if (jmConfig.typeHint) {
+    typeConfig.typeHint = jmConfig.typeHint
+  }
+  if (jmConfig.resolveType) {
+    typeConfig.resolveType = jmConfig.resolveType
+  }
   for (let fieldName in jmConfig.fields) {
     const field = type._fields[fieldName]
     assert(field, `Field "${fieldName}" not found in type "${type.name}".`)


### PR DESCRIPTION
Adds support for interfaces using the join monster typeHint and resolveType 
Rearranged README.md to indicate joinMonsterAdapt should be run against the schema output from makeExecutableSchema.
Bumped version to 0.0.1.