### PR TITLE
Update references to graphql tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Join Monster GraphQL Tools Adapter
 
-Use [Join Monster](https://github.com/stems/join-monster)'s SQL generation and query batching powers with Apollo server [graphql-tools](https://github.com/apollographql/graphql-tools)
+Use [Join Monster](https://github.com/stems/join-monster)'s SQL generation and query batching powers with the Apollo [graphql-tools](https://github.com/apollographql/graphql-tools) server package.
 
 ### What's this package for?
 


### PR DESCRIPTION
Just some copy edits!

I'd also appreciate if the description of the repository was updated to something like:

```
Use Join Monster to fetch your data with Apollo's graphql-tools.
```

Basically, I'm trying to update some references to `graphql-tools` around the internet, which can be used with any server package including `express-graphql` for example.