### PR TITLE
fix: Remove unnecessary graphql-tools dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   },
   "homepage": "https://github.com/acarl005/join-monster-graphql-tools-adapter#readme",
   "peerDependencies": {
-    "graphql-tools": "^0.4.0",
     "join-monster": "*"
   },
   "devDependencies": {


### PR DESCRIPTION
Version lock here can cause peerDependency issues when bundling with lerna and hoisting dependencies.
By removing this dependency, there isn't any more worry of peer conflicts blocking builds.

Also, thanks for the great repo!