### PR TITLE
Fix undefined resolveType issue

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,7 @@ function decorateType(type, jmConfig) {
     typeConfig.typeHint = jmConfig.typeHint
   }
   if (jmConfig.resolveType) {
-    typeConfig.resolveType = jmConfig.resolveType
+    type.resolveType = jmConfig.resolveType
   }
   for (let fieldName in jmConfig.fields) {
     const field = type._fields[fieldName]


### PR DESCRIPTION
Interface and union types `resolveType` resolution was broken.
GraphQLInterfaceType, GraphQLUnionType were missing the `resolveType` after `joinMonsterAdapt`, because `resolveType` field which should be set at type level and not in `type._typeConfig`.