### PR TITLE
Hack to get GraphQL 14 to work

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,18 +12,18 @@ module.exports = function joinMonsterAdapt(schema, jmConfigs) {
 
 function decorateType(type, jmConfig) {
   // first get the properties that should be on the type directly
-  const typeConfig = type._typeConfig
-  typeConfig.sqlTable = jmConfig.sqlTable
-  typeConfig.uniqueKey = jmConfig.uniqueKey
+  type._typeConfig = {}
+  type._typeConfig.sqlTable = jmConfig.sqlTable
+  type._typeConfig.uniqueKey = jmConfig.uniqueKey
   if (jmConfig.alwaysFetch) {
-    typeConfig.alwaysFetch = jmConfig.alwaysFetch
+    type._typeConfig.alwaysFetch = jmConfig.alwaysFetch
   }
   // These properties may appear for interface types
   if (jmConfig.typeHint) {
-    typeConfig.typeHint = jmConfig.typeHint
+    type._typeConfig.typeHint = jmConfig.typeHint
   }
   if (jmConfig.resolveType) {
-    typeConfig.resolveType = jmConfig.resolveType
+    type._typeConfig.resolveType = jmConfig.resolveType
   }
   for (let fieldName in jmConfig.fields) {
     const field = type._fields[fieldName]


### PR DESCRIPTION
Using the hack seen here https://github.com/acarl005/join-monster/issues/352#issuecomment-423985030, this allows join-monster-graphql-tools-adapter to work with GraphQL 14 until graphql-js adds something like extensions described here https://github.com/graphql/graphql-js/issues/1527. 

This could, for the time being, fix #12  